### PR TITLE
feat: add Themed Launcher Icon support

### DIFF
--- a/src/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/src/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/src/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/src/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
This PR adds support for Android's Themed Launcher Icon feature introduced in [Android 13](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)